### PR TITLE
isucon2 で easy_install で失敗するバグの修正

### DIFF
--- a/isucon2/playbook.yml
+++ b/isucon2/playbook.yml
@@ -143,7 +143,16 @@
     # supervisor package is too old
     # - yum: name=supervisor
     - yum: name=python-setuptools
-    - easy_install: name=supervisor
+
+    # see: http://dev.classmethod.jp/server-side/ansible/use_command_module_when_failed_easy_install_using_ansible_on_centos6/
+    # - easy_install: name=supervisor
+    - name: check supervisor command
+      stat:
+        path: /usr/bin/supervisor
+      register: _supervisor_stat_result
+    - name: install supervisor
+      command: "easy_install supervisor"
+      when: _supervisor_stat_result.stat.exists == false
     - copy: src=files/etc/init.d/supervisord dest=/etc/init.d/ mode=a+x
     - copy: src=files/etc/sysconfig/supervisord dest=/etc/sysconfig/
     - copy: src=files/etc/supervisord.conf dest=/etc/


### PR DESCRIPTION
# 事象
```
==> default: TASK [easy_install] ************************************************************
==> default: fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "warning: install_lib: 'build/lib' does not exist -- no Python modules to install\nTraceback (most recent call last):\n  File \"/usr/bin/easy_install\", line 9, in <module>\n    load_entry_point('distribute==0.6.10', 'console_scripts', 'easy_install')()\n  File \"/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py\", line 1715, in main\n    with_ei_usage(lambda:\n  File \"/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py\", line 1696, in with_ei_usage\n    return f()\n  File \"/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py\", line 1719, in <lambda>\n    distclass=DistributionWithoutHelpCommands, **kw\n  File \"/usr/lib64/python2.6/distutils/core.py\", line 152, in setup\n    dist.run_commands()\n  File \"/usr/lib64/python2.6/distutils/dist.py\", line 975, in run_commands\n    self.run_command(cmd)\n  File \"/usr/lib64/python2.6/distutils/dist.py\", line 995, in run_command\n    cmd_obj.run()\n  File \"/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py\", line 236, in run\n    self.easy_install(spec, not self.no_deps)\n  File \"/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py\", line 472, in easy_install\n    return self.install_item(spec, dist.location, tmpdir, deps)\n  File \"/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py\", line 502, in install_item\n    dists = self.install_eggs(spec, download, tmpdir)\n  File \"/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py\", line 681, in install_eggs\n    return self.build_and_install(setup_script, setup_base)\n  File \"/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py\", line 958, in build_and_install\n    self.run_setup(setup_script, setup_base, args)\n  File \"/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py\", line 947, in run_setup\n    run_setup(setup_script, args)\n  File \"/usr/lib/python2.6/site-packages/setuptools/sandbox.py\", line 29, in run_setup\n    lambda: execfile(\n  File \"/usr/lib/python2.6/site-packages/setuptools/sandbox.py\", line 70, in run\n    return func()\n  File \"/usr/lib/python2.6/site-packages/setuptools/sandbox.py\", line 31, in <lambda>\n    {'__file__':setup_script, '__name__':'__main__'}\n  File \"setup.py\", line 86, in <module>\n  File \"/usr/lib64/python2.6/distutils/core.py\", line 152, in setup\n    dist.run_commands()\n  File \"/usr/lib64/python2.6/distutils/dist.py\", line 975, in run_commands\n    self.run_command(cmd)\n  File \"/usr/lib64/python2.6/distutils/dist.py\", line 995, in run_command\n    cmd_obj.run()\n  File \"/usr/lib/python2.6/site-packages/setuptools/command/bdist_egg.py\", line 236, in run\n    dry_run=self.dry_run, mode=self.gen_header())\n  File \"/usr/lib/python2.6/site-packages/setuptools/command/bdist_egg.py\", line 533, in make_zipfile\n    visit(None, dirname, file)\n  File \"/usr/lib/python2.6/site-packages/setuptools/command/bdist_egg.py\", line 514, in visit\n    for name in names:\nTypeError: 'instancemethod' object is not iterable\n"}
```

# 修正内容
下記URLを参考に直した

参考: http://dev.classmethod.jp/server-side/ansible/use_command_module_when_failed_easy_install_using_ansible_on_centos6/